### PR TITLE
Build dll with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           run: |
             xml=$(curl https://vps.bvecornwall.co.uk/OpenBVE/Builds/version.xml)
             url1=${xml#*<url>}
-            url2=${one%</url>*}
+            url2=${url1%</url>*}
             curl -L "${url2}" -o ${GITHUB_WORKSPACE}/ob.zip
             unzip ${GITHUB_WORKSPACE}/ob.zip -d ${GITHUB_WORKSPACE}/ob
         - name: Build obDRPC

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+# Automatically build the project and run any configured tests for every push
+# and submitted pull request. This can help catch issues that only occur on
+# certain platforms or Java versions, and provides a first line of defence
+# against bad commits.
+
+name: Build
+on: [ push, pull_request ]
+
+jobs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up dependencies
+        run: |
+        sudo apt install gnupg ca-certificates
+        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+        echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+        sudo apt update
+        sudo apt install nuget
+        sudo apt install mono-complete
+      - name: Obtain OpenBVE
+        run: |
+        xml=$(curl https://vps.bvecornwall.co.uk/OpenBVE/Builds/version.xml)
+        url1=${xml#*<url>}
+        url2=${one%</url>*}
+        curl -L "${url2}" -o ${GITHUB_WORKSPACE}/ob.zip
+        unzip ${GITHUB_WORKSPACE}/ob.zip -d ${GITHUB_WORKSPACE}/ob
+      - name: Build obDRPC
+        run: |
+        cd ${GITHUB_WORKSPACE}
+        nuget restore
+        msbuild ${GITHUB_WORKSPACE}/obDRPC.csproj /p:OpenBveApiPath=${GITHUB_WORKSPACE}/ob/OpenBveApi.dll
+      - name: Capture release artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Artifacts
+          path: bin/debug/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,6 @@ jobs:
           with:
             name: Artifacts
             path: |
-            src/bin/debug/OB_DRPC.dll
-            src/bin/debug/OB_DRPC.dll.config
-            src/bin/debug/OB_DRPC.pdb
+              src/bin/debug/OB_DRPC.dll
+              src/bin/debug/OB_DRPC.dll.config
+              src/bin/debug/OB_DRPC.pdb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@
 # against bad commits.
 
 name: Build
-on: [ push, pull_request ]
+on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,4 +31,7 @@ jobs:
           uses: actions/upload-artifact@v3
           with:
             name: Artifacts
-            path: src/bin/debug/
+            path: |
+            src/bin/debug/OB_DRPC.dll
+            src/bin/debug/OB_DRPC.dll.config
+            src/bin/debug/OB_DRPC.pdb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,34 +5,34 @@
 
 name: Build
 on: [ push, pull_request, workflow_dispatch ]
-
 jobs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set up dependencies
-        run: |
-        sudo apt install gnupg ca-certificates
-        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-        echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-        sudo apt update
-        sudo apt install nuget
-        sudo apt install mono-complete
-      - name: Obtain OpenBVE
-        run: |
-        xml=$(curl https://vps.bvecornwall.co.uk/OpenBVE/Builds/version.xml)
-        url1=${xml#*<url>}
-        url2=${one%</url>*}
-        curl -L "${url2}" -o ${GITHUB_WORKSPACE}/ob.zip
-        unzip ${GITHUB_WORKSPACE}/ob.zip -d ${GITHUB_WORKSPACE}/ob
-      - name: Build obDRPC
-        run: |
-        cd ${GITHUB_WORKSPACE}
-        nuget restore
-        msbuild ${GITHUB_WORKSPACE}/obDRPC.csproj /p:OpenBveApiPath=${GITHUB_WORKSPACE}/ob/OpenBveApi.dll
-      - name: Capture release artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: Artifacts
-          path: bin/debug/
+    build:
+        runs-on: ubuntu-latest
+        steps:
+        - name: Checkout repository
+            uses: actions/checkout@v3
+        - name: Set up dependencies
+            run: |
+            sudo apt install gnupg ca-certificates
+            sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+            echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono- official-stable.list
+            sudo apt update
+            sudo apt install nuget
+            sudo apt install mono-complete
+        - name: Obtain OpenBVE
+            run: |
+            xml=$(curl https://vps.bvecornwall.co.uk/OpenBVE/Builds/version.xml)
+            url1=${xml#*<url>}
+            url2=${one%</url>*}
+            curl -L "${url2}" -o ${GITHUB_WORKSPACE}/ob.zip
+            unzip ${GITHUB_WORKSPACE}/ob.zip -d ${GITHUB_WORKSPACE}/ob
+        - name: Build obDRPC
+            run: |
+            cd ${GITHUB_WORKSPACE}
+            nuget restore
+            msbuild ${GITHUB_WORKSPACE}/obDRPC.csproj /p:OpenBveApiPath=${GITHUB_WORKSPACE}/ob/OpenBveApi.dll
+        - name: Capture release artifacts
+            uses: actions/upload-artifact@v3
+            with:
+            name: Artifacts
+            path: bin/debug/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - name: Checkout repository
-            uses: actions/checkout@v3
+          uses: actions/checkout@v3
         - name: Set up dependencies
-            run: |
+          run: |
             sudo apt install gnupg ca-certificates
             sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
             echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono- official-stable.list
@@ -20,19 +20,19 @@ jobs:
             sudo apt install nuget
             sudo apt install mono-complete
         - name: Obtain OpenBVE
-            run: |
+          run: |
             xml=$(curl https://vps.bvecornwall.co.uk/OpenBVE/Builds/version.xml)
             url1=${xml#*<url>}
             url2=${one%</url>*}
             curl -L "${url2}" -o ${GITHUB_WORKSPACE}/ob.zip
             unzip ${GITHUB_WORKSPACE}/ob.zip -d ${GITHUB_WORKSPACE}/ob
         - name: Build obDRPC
-            run: |
+          run: |
             cd ${GITHUB_WORKSPACE}
             nuget restore
             msbuild ${GITHUB_WORKSPACE}/obDRPC.csproj /p:OpenBveApiPath=${GITHUB_WORKSPACE}/ob/OpenBveApi.dll
         - name: Capture release artifacts
-            uses: actions/upload-artifact@v3
-            with:
+          uses: actions/upload-artifact@v3
+          with:
             name: Artifacts
             path: bin/debug/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,9 @@ jobs:
             unzip ${GITHUB_WORKSPACE}/ob.zip -d ${GITHUB_WORKSPACE}/ob
         - name: Build obDRPC
           run: |
-            cd ${GITHUB_WORKSPACE}
-            ls ${GITHUB_WORKSPACE}
+            cd ${GITHUB_WORKSPACE}/src
             nuget restore
-            msbuild ${GITHUB_WORKSPACE}/obDRPC.csproj /p:OpenBveApiPath=${GITHUB_WORKSPACE}/ob/OpenBveApi.dll
+            msbuild obDRPC.csproj /p:OpenBveApiPath=${GITHUB_WORKSPACE}/ob/OpenBveApi.dll
         - name: Capture release artifacts
           uses: actions/upload-artifact@v3
           with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,8 @@ jobs:
           uses: actions/checkout@v3
         - name: Set up dependencies
           run: |
-            sudo apt install gnupg ca-certificates
-            sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-            echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono- official-stable.list
             sudo apt update
             sudo apt install nuget
-            sudo apt install mono-complete
         - name: Obtain OpenBVE
           run: |
             xml=$(curl https://vps.bvecornwall.co.uk/OpenBVE/Builds/version.xml)
@@ -29,6 +25,7 @@ jobs:
         - name: Build obDRPC
           run: |
             cd ${GITHUB_WORKSPACE}
+            ls ${GITHUB_WORKSPACE}
             nuget restore
             msbuild ${GITHUB_WORKSPACE}/obDRPC.csproj /p:OpenBveApiPath=${GITHUB_WORKSPACE}/ob/OpenBveApi.dll
         - name: Capture release artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,11 @@ jobs:
         steps:
         - name: Checkout repository
           uses: actions/checkout@v3
-        - name: Set up dependencies
+        - name: Setup dependencies
           run: |
             sudo apt update
             sudo apt install nuget
-        - name: Obtain OpenBVE
+        - name: Download OpenBVE Nightly
           run: |
             xml=$(curl https://vps.bvecornwall.co.uk/OpenBVE/Builds/version.xml)
             url1=${xml#*<url>}
@@ -31,4 +31,4 @@ jobs:
           uses: actions/upload-artifact@v3
           with:
             name: Artifacts
-            path: bin/debug/
+            path: src/bin/debug/

--- a/src/obDRPC.csproj
+++ b/src/obDRPC.csproj
@@ -14,6 +14,7 @@
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <OpenBveApiPath Condition="'$(OpenBveApiPath)' == ''">../../../OpenBVE\OpenBVE-Nightly\OpenBveApi.dll</OpenBveApiPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -52,7 +53,7 @@
       <Version>3.3.3</Version>
     </PackageReference>
     <Reference Include="OpenBveApi">
-      <HintPath>..\..\..\OpenBVE\OpenBVE-Nightly\OpenBveApi.dll</HintPath>
+      <HintPath>$(OpenBveApiPath)</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
This PR adds an action workflow that will compile this plugin, steps goes as follows:
 - Install prerequisites packages such as nuget
 - Download the latest OpenBVE Nightly Build (For referencing the OpenBveApi.dll)
 - Restore nuget packages
 - Build this plugin
 - Capture the artifacts

This should make testing and future contributions easier. (Another more minor role is to test whether this plugin still compiles with the latest OpenBVE build, although unless OpenBVE changes something serious it should always compile)